### PR TITLE
SED-1636-New query builder logic

### DIFF
--- a/step-framework-parent/step-framework-timeseries/src/README.md
+++ b/step-framework-parent/step-framework-timeseries/src/README.md
@@ -1,0 +1,13 @@
+Let's assume we have a pipeline with resolution = 500
+
+Window examples:
+range [0, 2000) =>this will create one bucket / source resolution. result keys = [0, 500, 1000, 1500)
+range [0, 2000) + window(600) => window will be rounded to the closest source multiplier = 500. same result as above
+range [0, 3000) + window(1200) => result keys = [0, 1000, 2000], and result resolution = 1000
+range [400, 2000) => the range will alyways start from the lower source interval multiplier, so [0, 2000) in our case
+
+Split examples:
+range [0, 4000) + split(2) => result = [0, 2000)
+range [0, 4000) + split(3) => range is transformed to [0, 4500], with resolution 1500, the result keys will be [0, 1500, 3000)
+range [0, 4000) + split(7) => range is transformed to [0, 7000)  the resolution is 571, rounded to nearest multiple will be 500
+range [0, 1000) + range(5) => this is a situation when the buckets count is also not respected, because the resolution don't allow us. [0, 500) is returned

--- a/step-framework-parent/step-framework-timeseries/src/main/java/step/core/timeseries/TimeSeriesFilterBuilder.java
+++ b/step-framework-parent/step-framework-timeseries/src/main/java/step/core/timeseries/TimeSeriesFilterBuilder.java
@@ -60,7 +60,7 @@ public class TimeSeriesFilterBuilder {
     }
 
     public static Filter buildFilter(TimeSeriesAggregationQuery query) {
-        Filter timestampFilter = TimeSeriesFilterBuilder.buildFilter(query.getBucketIndexFrom(), query.getBucketIndexTo());
+        Filter timestampFilter = TimeSeriesFilterBuilder.buildFilter(query.getFrom(), query.getTo());
 
         return Filters.and(Arrays.asList(query.getFilter(), timestampFilter));
     }

--- a/step-framework-parent/step-framework-timeseries/src/main/java/step/core/timeseries/aggregation/TimeSeriesAggregationQueryBuilder.java
+++ b/step-framework-parent/step-framework-timeseries/src/main/java/step/core/timeseries/aggregation/TimeSeriesAggregationQueryBuilder.java
@@ -10,18 +10,19 @@ public class TimeSeriesAggregationQueryBuilder {
 
     private final TimeSeriesAggregationPipeline pipeline;
     private final long sourceResolution;
-    private long resultResolution;
     private Set<String> groupDimensions = new HashSet<>();
-    private Filter filter = Filters.empty();;
-    private boolean shrink;
+    private Filter filter = Filters.empty();
+    ;
     private Long from;
     private Long to;
+    private boolean shrink;
+    private Long proposedResolution;
+    private Integer bucketsCount;
 
 
     public TimeSeriesAggregationQueryBuilder(TimeSeriesAggregationPipeline aggregationPipeline) {
         this.pipeline = aggregationPipeline;
         this.sourceResolution = aggregationPipeline.getSourceResolution();
-        this.resultResolution = sourceResolution;
     }
 
     public TimeSeriesAggregationQueryBuilder withGroupDimensions(Set<String> groupDimensions) {
@@ -31,11 +32,6 @@ public class TimeSeriesAggregationQueryBuilder {
 
     public TimeSeriesAggregationQueryBuilder withFilter(Filter filter) {
         this.filter = filter;
-        return this;
-    }
-
-    public TimeSeriesAggregationQueryBuilder withShrink(boolean shrink) {
-        this.shrink = shrink;
         return this;
     }
 
@@ -56,47 +52,61 @@ public class TimeSeriesAggregationQueryBuilder {
         if (resolution < sourceResolution) {
             throw new IllegalArgumentException("The resolution cannot be lower than the source resolution of " + sourceResolution + "ms");
         }
-        this.resultResolution = Math.max(sourceResolution, resolution - resolution % sourceResolution);
+        this.proposedResolution = resolution;
         return this;
     }
 
-    /**
-     * Specifies the desired number of buckets in the result.
-     * - For targetNumberOfBuckets = 1 the resulting number of buckets will be exactly 1
-     * - For targetNumberOfBuckets > 1 the resulting number of buckets will be as close as possible to the specified target
-     *
-     * @param targetNumberOfBuckets the desired number of buckets in the result
-     * @return the builder
-     */
-    public TimeSeriesAggregationQueryBuilder split(long targetNumberOfBuckets) {
+    public TimeSeriesAggregationQueryBuilder split(int targetNumberOfBuckets) {
         if (targetNumberOfBuckets == 1) {
             shrink = true;
-            window(Long.MAX_VALUE);
         } else {
-            if (from == null || to == null) {
-                throw new IllegalArgumentException("No range specified. The method range() should be called before calling split()");
-            }
-            long targetResolution = (long) Math.ceil((double) (to - from) / targetNumberOfBuckets);
-            long resolution = targetResolution - targetResolution % sourceResolution;
-            this.resultResolution = Math.max(sourceResolution, resolution);
+            this.bucketsCount = targetNumberOfBuckets;
         }
         return this;
     }
 
+
+    /**
+     * The precedence of settings applied: shrink > bucketsCount > proposedResolution
+     */
     public TimeSeriesAggregationQuery build() {
         Long resultFrom = null;
         Long resultTo = null;
+        long resultResolution = sourceResolution;
+        if (bucketsCount != null && (from == null || to == null)) {
+            throw new IllegalArgumentException("While splitting, from and to params must be set");
+        }
         if (from != null && to != null) {
-            if (shrink) {
-                resultFrom = from - from % sourceResolution;
-                resultTo = to - to % sourceResolution + sourceResolution;
+            resultFrom = from - from % sourceResolution;
+            resultTo = (long) Math.ceil((double) to / sourceResolution) * sourceResolution;
+            if (shrink) { // we expand the interval to the closest completed resolutions
+//                resultFrom = from - from % sourceResolution;
+//                resultTo = to - to % sourceResolution + sourceResolution;
+                resultResolution = Long.MAX_VALUE;
             } else {
-                resultFrom = from - from % resultResolution;
-                resultTo = to - (to - resultFrom) % resultResolution + resultResolution;
+                if (this.bucketsCount != null && this.bucketsCount > 0) {
+                    resultFrom = from - from % sourceResolution;
+                    resultTo = (long) Math.ceil((double) to / sourceResolution) * sourceResolution;
+                    if ((resultTo - resultFrom) / sourceResolution <= this.bucketsCount) { // not enough buckets
+//                        resultTo = resultFrom + this.bucketsCount * sourceResolution;
+                        resultResolution = sourceResolution;
+                    } else {
+                        long difference = resultTo - resultFrom;
+                        resultResolution = (long) Math.ceil(difference / (double) bucketsCount);
+                        resultResolution = (long) Math.ceil((double) resultResolution / sourceResolution) * sourceResolution;
+                        resultTo = resultFrom + (resultResolution * bucketsCount);
+
+                    }
+                } else if (this.proposedResolution != null && this.proposedResolution != 0) {
+                    resultResolution = Math.max(sourceResolution, proposedResolution - proposedResolution % sourceResolution);
+                    resultResolution = resultResolution - resultResolution % sourceResolution;
+                    resultFrom = from - from % sourceResolution;
+                    resultTo = (long) Math.ceil((double) to / resultResolution) * resultResolution;
+                }
             }
         }
 
-        return new TimeSeriesAggregationQuery(pipeline, filter, groupDimensions, from, to, resultFrom, resultTo, resultResolution, shrink);
+        return new TimeSeriesAggregationQuery(pipeline, filter, groupDimensions, resultFrom, resultTo, resultResolution, shrink);
     }
 
 

--- a/step-framework-parent/step-framework-timeseries/src/main/java/step/core/timeseries/aggregation/TimeSeriesAggregationQueryBuilder.java
+++ b/step-framework-parent/step-framework-timeseries/src/main/java/step/core/timeseries/aggregation/TimeSeriesAggregationQueryBuilder.java
@@ -87,11 +87,12 @@ public class TimeSeriesAggregationQueryBuilder {
                     resultTo = (long) Math.ceil((double) to / sourceResolution) * sourceResolution;
                     if ((resultTo - resultFrom) / sourceResolution <= this.bucketsCount) { // not enough buckets
                         resultResolution = sourceResolution;
+                        resultTo = (long) Math.ceil((double)to / sourceResolution) * sourceResolution;
                     } else {
                         long difference = resultTo - resultFrom;
-                        resultResolution = (long) Math.ceil(difference / (double) bucketsCount);
-                        resultResolution = (long) Math.ceil((double) resultResolution / sourceResolution) * sourceResolution;
-                        resultTo = resultFrom + (resultResolution * bucketsCount);
+                        resultResolution =  Math.round(difference / (double) bucketsCount);
+                        resultResolution =  Math.round((double) resultResolution / sourceResolution) * sourceResolution; // round to nearest multiple
+//                        resultTo = resultFrom + (resultResolution * bucketsCount);
 
                     }
                 } else if (this.proposedResolution != null && this.proposedResolution != 0) {

--- a/step-framework-parent/step-framework-timeseries/src/main/java/step/core/timeseries/aggregation/TimeSeriesAggregationQueryBuilder.java
+++ b/step-framework-parent/step-framework-timeseries/src/main/java/step/core/timeseries/aggregation/TimeSeriesAggregationQueryBuilder.java
@@ -80,15 +80,12 @@ public class TimeSeriesAggregationQueryBuilder {
             resultFrom = from - from % sourceResolution;
             resultTo = (long) Math.ceil((double) to / sourceResolution) * sourceResolution;
             if (shrink) { // we expand the interval to the closest completed resolutions
-//                resultFrom = from - from % sourceResolution;
-//                resultTo = to - to % sourceResolution + sourceResolution;
                 resultResolution = Long.MAX_VALUE;
             } else {
                 if (this.bucketsCount != null && this.bucketsCount > 0) {
                     resultFrom = from - from % sourceResolution;
                     resultTo = (long) Math.ceil((double) to / sourceResolution) * sourceResolution;
                     if ((resultTo - resultFrom) / sourceResolution <= this.bucketsCount) { // not enough buckets
-//                        resultTo = resultFrom + this.bucketsCount * sourceResolution;
                         resultResolution = sourceResolution;
                     } else {
                         long difference = resultTo - resultFrom;

--- a/step-framework-parent/step-framework-timeseries/src/test/java/step/core/timeseries/TimeSeriesAggergationQueryTest.java
+++ b/step-framework-parent/step-framework-timeseries/src/test/java/step/core/timeseries/TimeSeriesAggergationQueryTest.java
@@ -5,6 +5,8 @@ import org.junit.Test;
 import step.core.collections.inmemory.InMemoryCollection;
 import step.core.ql.OQLFilterBuilder;
 import step.core.timeseries.aggregation.TimeSeriesAggregationPipeline;
+import step.core.timeseries.aggregation.TimeSeriesAggregationQuery;
+import step.core.timeseries.aggregation.TimeSeriesAggregationResponse;
 import step.core.timeseries.bucket.Bucket;
 
 import java.util.Map;
@@ -32,14 +34,6 @@ public class TimeSeriesAggergationQueryTest {
                 .window(10);
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void intervalNotSetTest() {
-        InMemoryCollection<Bucket> bucketCollection = new InMemoryCollection<>();
-        TimeSeries timeSeries = new TimeSeries(bucketCollection, Set.of(), 10);
-        timeSeries.getAggregationPipeline()
-                .newQueryBuilder()
-                .split(10);
-    }
 
     @Test
     public void shrinkTest() {
@@ -75,7 +69,31 @@ public class TimeSeriesAggergationQueryTest {
                 .run().getSeries().size();
         // we want to make sure that the methods above are not failing
         Assert.assertEquals(0, seriesSize);
+    }
 
+    @Test
+    public void queryIntervalPrecisionTest() {
+        InMemoryCollection<Bucket> bucketCollection = new InMemoryCollection<>();
+        int bucketsCount = 20;
+        for (int i = 0; i < bucketsCount; i++) {
+            Bucket bucket = new Bucket();
+            bucket.setBegin(i * 1000);
+            bucketCollection.save(bucket);
+        }
+        TimeSeries timeSeries = new TimeSeries(bucketCollection, Set.of(), 200);
+        TimeSeriesAggregationPipeline pipeline = timeSeries.getAggregationPipeline();
+        String oql = "";
+        int split = 5;
+        TimeSeriesAggregationQuery query = pipeline.newQueryBuilder()
+                .range(0, 1000 * bucketsCount / 2)
+                .split(split)
+                .withFilter(OQLFilterBuilder.getFilter(oql))
+                .build();
+        TimeSeriesAggregationResponse response = query.run();
+        // we want to make sure that the methods above are not failing
+        Assert.assertEquals(1, response.getSeries().size());
+        Map<Long, Bucket> seriesResponse = response.getFirstSeries();
+        Assert.assertEquals(split, seriesResponse.size());
     }
 
 }

--- a/step-framework-parent/step-framework-timeseries/src/test/java/step/core/timeseries/TimeSeriesAggregationQueryBuilderTest.java
+++ b/step-framework-parent/step-framework-timeseries/src/test/java/step/core/timeseries/TimeSeriesAggregationQueryBuilderTest.java
@@ -98,6 +98,15 @@ public class TimeSeriesAggregationQueryBuilderTest {
         Assert.assertEquals(1000, query.getResolution());
         Assert.assertEquals(500, query.getFrom().longValue());
         Assert.assertEquals(5500, query.getTo().longValue());
+
+        query = createPipeline(500)
+                .newQueryBuilder()
+                .range(800, 6000) // should be transformed to 500-6000
+                .split(5)
+                .build();
+        Assert.assertEquals(1000, query.getResolution());
+        Assert.assertEquals(500, query.getFrom().longValue());
+        Assert.assertEquals(6000, query.getTo().longValue());
     }
 
     @Test
@@ -110,6 +119,42 @@ public class TimeSeriesAggregationQueryBuilderTest {
         Assert.assertEquals(500, query.getResolution());
         Assert.assertEquals(4000, query.getFrom().longValue());
         Assert.assertEquals(5000, query.getTo().longValue());
+
+        query = createPipeline(500)
+                .newQueryBuilder()
+                .range(4000, 5100) // there is not enough space for 4 minimum buckets
+                .split(5)
+                .build();
+        Assert.assertEquals(500, query.getResolution());
+        Assert.assertEquals(4000, query.getFrom().longValue());
+        Assert.assertEquals(5500, query.getTo().longValue());
+
+        query = createPipeline(300)
+                .newQueryBuilder()
+                .range(1000, 2000) // there is not enough space for 4 minimum buckets
+                .split(15)
+                .build();
+        Assert.assertEquals(300, query.getResolution());
+        Assert.assertEquals(900, query.getFrom().longValue());
+        Assert.assertEquals(2100, query.getTo().longValue());
+
+        query = createPipeline(500)
+                .newQueryBuilder()
+                .range(1000, 2600) // there is not enough space for 4 minimum buckets
+                .split(3)
+                .build();
+        Assert.assertEquals(500, query.getResolution());
+        Assert.assertEquals(1000, query.getFrom().longValue());
+        Assert.assertEquals(3000, query.getTo().longValue());
+
+        query = createPipeline(500)
+                .newQueryBuilder()
+                .range(0, 2900) // there is not enough space for 4 minimum buckets
+                .split(3)
+                .build();
+        Assert.assertEquals(1000, query.getResolution());
+        Assert.assertEquals(0, query.getFrom().longValue());
+        Assert.assertEquals(3000, query.getTo().longValue());
     }
 
     /**
@@ -125,7 +170,7 @@ public class TimeSeriesAggregationQueryBuilderTest {
                 .build();
         Assert.assertEquals(600, query.getResolution());
         Assert.assertEquals(900, query.getFrom().longValue());
-        Assert.assertEquals(3300, query.getTo().longValue());
+        Assert.assertEquals(3000, query.getTo().longValue());
     }
 
     private static TimeSeriesAggregationPipeline createPipeline(int sourceResolution) {

--- a/step-framework-parent/step-framework-timeseries/src/test/java/step/core/timeseries/TimeSeriesAggregationQueryBuilderTest.java
+++ b/step-framework-parent/step-framework-timeseries/src/test/java/step/core/timeseries/TimeSeriesAggregationQueryBuilderTest.java
@@ -1,0 +1,137 @@
+package step.core.timeseries;
+
+import org.junit.Assert;
+import org.junit.Test;
+import step.core.collections.inmemory.InMemoryCollection;
+import step.core.timeseries.aggregation.TimeSeriesAggregationPipeline;
+import step.core.timeseries.aggregation.TimeSeriesAggregationQuery;
+import step.core.timeseries.bucket.Bucket;
+
+import java.util.Set;
+
+public class TimeSeriesAggregationQueryBuilderTest {
+
+    @Test
+    public void emptyQueryTest() {
+        TimeSeriesAggregationQuery query = createPipeline(1000)
+                .newQueryBuilder()
+                .build();
+        Assert.assertEquals(1000, query.getResolution());
+        Assert.assertNull(query.getFrom());
+        Assert.assertNull(query.getTo());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void windowWithNoRangeTest() {
+        TimeSeriesAggregationQuery query = createPipeline(1000)
+                .newQueryBuilder()
+                .window(200)
+                .build();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void tooLowWindowTest() {
+        TimeSeriesAggregationQuery query = createPipeline(1000)
+                .newQueryBuilder()
+                .range(1000, 5000)
+                .window(800)
+                .build();
+    }
+
+    @Test
+    public void perfectRangeRoundingTest() {
+        TimeSeriesAggregationQuery query = createPipeline(1000)
+                .newQueryBuilder()
+                .range(1000, 5000)
+                .build();
+        Assert.assertEquals(1000, query.getResolution());
+        Assert.assertEquals(1000, query.getFrom().longValue());
+        Assert.assertEquals(5000, query.getTo().longValue());
+    }
+
+    /**
+     * The window interval should be rounded to the smallest source resolution multiplier.
+     */
+    @Test()
+    public void windowRoundingTest() {
+        TimeSeriesAggregationQuery query = createPipeline(1000)
+                .newQueryBuilder()
+                .range(1000, 5000)
+                .window(1200)
+                .build();
+        Assert.assertEquals(1000, query.getResolution());
+
+        query = createPipeline(1000)
+                .newQueryBuilder()
+                .range(1000, 5000)
+                .window(1900) // should round to 1000
+                .build();
+        Assert.assertEquals(1000, query.getResolution());
+
+        query = createPipeline(1000)
+                .newQueryBuilder()
+                .range(1000, 5000)
+                .window(2100) // should round to 2000
+                .build();
+        Assert.assertEquals(2000, query.getResolution());
+    }
+
+    @Test
+    public void simpleShrinkTest() {
+        TimeSeriesAggregationQuery query = createPipeline(1000)
+                .newQueryBuilder()
+                .range(800, 5200)
+                .split(1) // shrink
+                .build();
+        Assert.assertEquals(Long.MAX_VALUE, query.getResolution());
+        Assert.assertEquals(0, query.getFrom().longValue());
+        Assert.assertEquals(6000, query.getTo().longValue());
+    }
+
+    @Test
+    public void enoughSplitTest() {
+        TimeSeriesAggregationQuery query = createPipeline(500)
+                .newQueryBuilder()
+                .range(800, 5500) // should be transformed to 500-5500
+                .split(5)
+                .build();
+        Assert.assertEquals(1000, query.getResolution());
+        Assert.assertEquals(500, query.getFrom().longValue());
+        Assert.assertEquals(5500, query.getTo().longValue());
+    }
+
+    @Test
+    public void insufficientSplitTest() {
+        TimeSeriesAggregationQuery query = createPipeline(500)
+                .newQueryBuilder()
+                .range(4000, 5000) // there is not enough space for 4 minimum buckets
+                .split(4)
+                .build();
+        Assert.assertEquals(500, query.getResolution());
+        Assert.assertEquals(4000, query.getFrom().longValue());
+        Assert.assertEquals(5000, query.getTo().longValue());
+    }
+
+    /**
+     * Split must take precedence
+     */
+    @Test
+    public void splitVsResolutionPriorityTest() {
+        TimeSeriesAggregationQuery query = createPipeline(300)
+                .newQueryBuilder()
+                .range(1000, 3000) // 900 to 3000 = 3900
+                .window(1000)
+                .split(4)
+                .build();
+        Assert.assertEquals(600, query.getResolution());
+        Assert.assertEquals(900, query.getFrom().longValue());
+        Assert.assertEquals(3300, query.getTo().longValue());
+    }
+
+    private static TimeSeriesAggregationPipeline createPipeline(int sourceResolution) {
+        InMemoryCollection<Bucket> bucketCollection = new InMemoryCollection<>();
+        TimeSeries timeSeries = new TimeSeries(bucketCollection, Set.of(), sourceResolution);
+        return timeSeries.getAggregationPipeline();
+    }
+
+}

--- a/step-framework-parent/step-framework-timeseries/src/test/java/step/core/timeseries/TimeSeriesTest.java
+++ b/step-framework-parent/step-framework-timeseries/src/test/java/step/core/timeseries/TimeSeriesTest.java
@@ -198,18 +198,37 @@ public class TimeSeriesTest {
         assertEquals(response.getResolution(), firstBucket.getEnd() - firstBucket.getBegin());
 
         // Use source resolution
-        series1 = aggregationPipeline.newQueryBuilder().withFilter(TimeSeriesFilterBuilder.buildFilter(attributes)).range(start, now).build().run().getFirstSeries();
+        series1 = aggregationPipeline
+                .newQueryBuilder()
+                .withFilter(TimeSeriesFilterBuilder.buildFilter(attributes))
+                .range(start, now).build()
+                .run()
+                .getFirstSeries();
         assertEquals(count.longValue(), countPoints(series1));
         assertTrue(series1.size() > duration / timeSeriesResolution);
 
         // Use double source resolution
         int window = timeSeriesResolution * 2;
-        series1 = aggregationPipeline.newQueryBuilder().withFilter(TimeSeriesFilterBuilder.buildFilter(attributes)).range(start, now).window(window).build().run().getFirstSeries();
+        series1 = aggregationPipeline
+                .newQueryBuilder()
+                .withFilter(TimeSeriesFilterBuilder.buildFilter(attributes))
+                .range(start, now)
+                .window(window)
+                .build()
+                .run()
+                .getFirstSeries();
         assertEquals(count.longValue(), countPoints(series1));
         assertTrue(series1.size() > duration / window);
 
         // Use
-        Map<Long, Bucket> series2 = aggregationPipeline.newQueryBuilder().withFilter(TimeSeriesFilterBuilder.buildFilter(attributes2)).range(start, now).window(now - start).build().run().getFirstSeries();
+        Map<Long, Bucket> series2 = aggregationPipeline
+                .newQueryBuilder()
+                .withFilter(TimeSeriesFilterBuilder.buildFilter(attributes2))
+                .range(start, now)
+                .window(now - start)
+                .build()
+                .run()
+                .getFirstSeries();
         assertEquals(count.longValue(), countPoints(series2));
         assertTrue(series2.size() <= 2);
     }


### PR DESCRIPTION
Differences:

```
1. Buckets count is always respected in the response (excepting the extreme situation described in the below example)
2. The buckets are always combined equally- there will be no spikes in the beginning, middle, or end of the timeseries, because of unlinear grouping (e.g the last interval is shorter than the other intervals)
3. There is only one place where the query building logic happens (`build()` method). All the parameters are accumulated, and they are combined just in the end.
```

I will summarize below the changes via a few example, so you can get the actual behavior:

Let's assume we have a pipeline with resolution = 500

There are 2 big options when asking for an aggregation: **Window** (custom resolution in response) and **Split** (number of buckets)

Window examples:
`range [0, 2000)` =>this will create one bucket / source resolution. result keys = `[0, 500, 1000, 1500)`
`range [0, 2000) + window(600)` => window will be rounded to the closest source multiplier = 500. same result as above
`range [0, 3000) + window(1200)` => result keys = `[0, 1000, 2000]`, and result resolution = 1000
`range [400, 2000)` => the range will alyways start from the lower source interval multiplier, so `[0, 2000)` in our case

Split examples:
`range [0, 4000) + split(2) `=> result =` [0, 2000)`
`range [0, 4000) + split(3)` => range is transformed to `[0, 4500]`, with resolution 1500, the result keys will be `[0, 1500, 3000)`
`range [0, 4000) + split(7) `=> range is transformed to `[0, 7000) ` because the resolution is too small, result being `[0, 1000, 2000, 3000, 4000, 5000, 6000)` - this is very unlikely to happen
`range [0, 1000) + range(5)` => this is the only situation when the buckets count is not respected, because the resolution don't allow us. `[0, 500)` is returned

This was tested with the frontend too.