### PR TITLE
SED-2881 support object fields in collections

### DIFF
--- a/step-framework-parent/step-framework-collections-mongodb/src/test/java/step/core/accessors/mongodb/MongoDBAccessorTest.java
+++ b/step-framework-parent/step-framework-collections-mongodb/src/test/java/step/core/accessors/mongodb/MongoDBAccessorTest.java
@@ -24,11 +24,16 @@ public class MongoDBAccessorTest extends AbstractAccessorTest {
 				mongoDBCollectionFactory.getCollection("abstractOrganizableObject", AbstractOrganizableObject.class));
 		beanAccessor = new AbstractAccessor<Bean>(
 				mongoDBCollectionFactory.getCollection("bean", Bean.class));
+		pseudoBeanAccessor = new AbstractAccessor<>(
+				mongoDBCollectionFactory.getCollection("pseudoBean", PseudoBean.class));
 		accessor.getCollectionDriver().remove(Filters.empty());
 		organizableObjectAccessor.getCollectionDriver().remove(Filters.empty());
 		beanAccessor.getCollectionDriver().remove(Filters.empty());
+		pseudoBeanAccessor.getCollectionDriver().remove(Filters.empty());
 		Collection<EntityVersion> versionedBeanCollection = mongoDBCollectionFactory.getVersionedCollection("bean");
 		versionedBeanCollection.remove(Filters.empty());
+		Collection<EntityVersion> versionedPseudoBeanCollection = mongoDBCollectionFactory.getVersionedCollection("pseudoBean");
+		versionedPseudoBeanCollection.remove(Filters.empty());
 	}
 
 

--- a/step-framework-parent/step-framework-collections-mongodb/src/test/java/step/core/accessors/mongodb/MongoDBVersionedAccessorTest.java
+++ b/step-framework-parent/step-framework-collections-mongodb/src/test/java/step/core/accessors/mongodb/MongoDBVersionedAccessorTest.java
@@ -10,30 +10,32 @@ import step.core.collections.EntityVersion;
 import step.core.collections.Filters;
 import step.core.collections.mongodb.MongoDBCollectionFactory;
 
-import java.io.IOException;
 import java.util.Properties;
 
 public class MongoDBVersionedAccessorTest extends AbstractVersionedAccessorTest {
 
 	@Before
-	public void before() throws IOException {
+	public void before() {
 		MongoDBCollectionFactory mongoDBCollectionFactory = new MongoDBCollectionFactory(getProperties());
 
-		accessor = new AbstractAccessor<AbstractIdentifiableObject>(mongoDBCollectionFactory.getCollection("abstractIdentifiableObject", AbstractIdentifiableObject.class));
-		organizableObjectAccessor = new AbstractAccessor<AbstractOrganizableObject>(
-				mongoDBCollectionFactory.getCollection("abstractOrganizableObject", AbstractOrganizableObject.class));
-		beanAccessor = new AbstractAccessor<Bean>(
-				mongoDBCollectionFactory.getCollection("bean", Bean.class));
+		accessor = new AbstractAccessor<>(mongoDBCollectionFactory.getCollection("abstractIdentifiableObject", AbstractIdentifiableObject.class));
+		organizableObjectAccessor = new AbstractAccessor<>(mongoDBCollectionFactory.getCollection("abstractOrganizableObject", AbstractOrganizableObject.class));
+		beanAccessor = new AbstractAccessor<>(mongoDBCollectionFactory.getCollection("bean", Bean.class));
+		pseudoBeanAccessor = new AbstractAccessor<>(mongoDBCollectionFactory.getCollection("pseudoBean", PseudoBean.class));
 		accessor.getCollectionDriver().remove(Filters.empty());
 		organizableObjectAccessor.getCollectionDriver().remove(Filters.empty());
 		beanAccessor.getCollectionDriver().remove(Filters.empty());
+		pseudoBeanAccessor.getCollectionDriver().remove(Filters.empty());
 		Collection<EntityVersion> versionedBeanCollection = mongoDBCollectionFactory.getVersionedCollection("bean");
 		versionedBeanCollection.remove(Filters.empty());
-		beanAccessor.enableVersioning(versionedBeanCollection, 1l);
+		Collection<EntityVersion> versionedPseudoBeanCollection = mongoDBCollectionFactory.getVersionedCollection("pseudoBean");
+		versionedPseudoBeanCollection.remove(Filters.empty());
+		beanAccessor.enableVersioning(versionedBeanCollection, 1L);
+		pseudoBeanAccessor.enableVersioning(versionedPseudoBeanCollection, 1L);
 	}
 
 
-	private static Properties getProperties() throws IOException {
+	private static Properties getProperties() {
 		Properties properties = new Properties();
 		properties.put("host", "central-mongodb.stepcloud-test.ch");
 		//properties.put("host", "localhost");

--- a/step-framework-parent/step-framework-collections-postgresql/src/main/java/step/core/collections/postgresql/PostgreSQLCollection.java
+++ b/step-framework-parent/step-framework-collections-postgresql/src/main/java/step/core/collections/postgresql/PostgreSQLCollection.java
@@ -338,7 +338,7 @@ public class PostgreSQLCollection<T> extends AbstractCollection<T> implements Co
 	}
 
 	private void createIndex(String indexId, String index) {
-		String query = "CREATE INDEX IF NOT EXISTS " + indexId + " ON " + collectionName + " " + index;
+		String query = "CREATE INDEX IF NOT EXISTS " + indexId + " ON " + collectionNameStr + " " + index;
 		if (index.contains("$**")) {
 			logger.error("The wildcard not supported for index in postgres, skipping index creation for: " + query);
 		} else {

--- a/step-framework-parent/step-framework-collections-postgresql/src/test/java/step/core/accessors/postgresql/PostgreSQLAccessorTest.java
+++ b/step-framework-parent/step-framework-collections-postgresql/src/test/java/step/core/accessors/postgresql/PostgreSQLAccessorTest.java
@@ -23,17 +23,21 @@ public class PostgreSQLAccessorTest extends AbstractAccessorTest {
 	public void before() throws IOException {
 		jdbcDBCollectionFactory = new PostgreSQLCollectionFactory(getProperties());
 
-		accessor = new AbstractAccessor<AbstractIdentifiableObject>(jdbcDBCollectionFactory.getCollection("abstractIdentifiableObject", AbstractIdentifiableObject.class));
-		organizableObjectAccessor = new AbstractAccessor<AbstractOrganizableObject>(
-				jdbcDBCollectionFactory.getCollection("abstractOrganizableObject", AbstractOrganizableObject.class));
-		beanAccessor = new AbstractAccessor<AbstractAccessorTest.Bean>(
-				jdbcDBCollectionFactory.getCollection("bean", AbstractAccessorTest.Bean.class));
-		Collection<EntityVersion> versionedCollection = jdbcDBCollectionFactory.getVersionedCollection("bean");
-		versionedCollection.remove(Filters.empty());
-		beanAccessor.enableVersioning(versionedCollection, 1l);
+		accessor = new AbstractAccessor<>(jdbcDBCollectionFactory.getCollection("abstractIdentifiableObject", AbstractIdentifiableObject.class));
+		organizableObjectAccessor = new AbstractAccessor<>(jdbcDBCollectionFactory.getCollection("abstractOrganizableObject", AbstractOrganizableObject.class));
+		beanAccessor = new AbstractAccessor<>(jdbcDBCollectionFactory.getCollection("bean", AbstractAccessorTest.Bean.class));
+		Collection<EntityVersion> versionedBeanCollection = jdbcDBCollectionFactory.getVersionedCollection("bean");
+		versionedBeanCollection.remove(Filters.empty());
+		beanAccessor.enableVersioning(versionedBeanCollection, 1L);
+		pseudoBeanAccessor = new AbstractAccessor<>(jdbcDBCollectionFactory.getCollection("pseudoBean", PseudoBean.class));
+		Collection<EntityVersion> versionedPseudoBeanCollection = jdbcDBCollectionFactory.getVersionedCollection("pseudoBean");
+		versionedPseudoBeanCollection.remove(Filters.empty());
+		pseudoBeanAccessor.enableVersioning(versionedPseudoBeanCollection, 1L);
+
 		accessor.getCollectionDriver().remove(Filters.empty());
 		organizableObjectAccessor.getCollectionDriver().remove(Filters.empty());
 		beanAccessor.getCollectionDriver().remove(Filters.empty());
+		pseudoBeanAccessor.getCollectionDriver().remove(Filters.empty());
 	}
 
 	@After

--- a/step-framework-parent/step-framework-collections/src/main/java/step/core/collections/PojoUtils.java
+++ b/step-framework-parent/step-framework-collections/src/main/java/step/core/collections/PojoUtils.java
@@ -20,7 +20,20 @@ public class PojoUtils {
             return beanUtilsBean.getPropertyUtils().getNestedProperty(bean, propertyName);
         } catch (NestedNullException e) {
             return null;
+        } catch (NoSuchMethodException noSuchMethod) {
+            try {
+                // fallback, try to get the field with the given name
+                return getField(bean, propertyName);
+            } catch (NoSuchFieldException ignored) {
+                // keep existing behavior - no such method, and no field either,
+                // so we just throw the same exception we always did
+                throw noSuchMethod;
+            }
         }
+    }
+
+    private static Object getField(Object bean, String propertyName) throws NoSuchFieldException, IllegalAccessException {
+        return bean == null ? null : bean.getClass().getField(propertyName).get(bean);
     }
 
     public static Comparator<Object> comparator(String propertyName) {

--- a/step-framework-parent/step-framework-collections/src/test/java/step/core/accessors/AbstractAccessorTest.java
+++ b/step-framework-parent/step-framework-collections/src/test/java/step/core/accessors/AbstractAccessorTest.java
@@ -4,9 +4,7 @@ import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
-import org.bson.types.ObjectId;
 import org.junit.Test;
-import step.core.collections.EntityVersion;
 
 import static org.junit.Assert.*;
 
@@ -15,7 +13,8 @@ public abstract class AbstractAccessorTest {
 	protected Accessor<AbstractIdentifiableObject> accessor;
 	protected Accessor<AbstractOrganizableObject> organizableObjectAccessor;
 	protected Accessor<Bean> beanAccessor;
-	
+	protected Accessor<PseudoBean> pseudoBeanAccessor;
+
 	public AbstractAccessorTest() {
 		super();
 	}
@@ -78,26 +77,62 @@ public abstract class AbstractAccessorTest {
         assertTrue(foundObjects.stream().anyMatch(o -> o.getId().toString().equals(entity2.getId().toString())));
 
     }
-	
+
 	@Test
 	public void testBeanAccessor() {
 		Bean entity = new Bean();
 		entity.setProperty1("value 1");
 		beanAccessor.save(entity);
-		
+
 		Bean actualEntity = beanAccessor.get(entity.getId());
 		assertEquals(entity, actualEntity);
-		
+
 		actualEntity = beanAccessor.get(entity.getId().toString());
 		assertEquals(entity, actualEntity);
-		
+
 		actualEntity = beanAccessor.findByCriteria(Map.of("property1", "value 1"));
 		assertEquals(entity, actualEntity);
-		
+
 		actualEntity = beanAccessor.findManyByCriteria(Map.of("property1", "value 1")).findFirst().get();
 		assertEquals(entity, actualEntity);
 
 		actualEntity = beanAccessor.findByCriteria(new HashMap<> ());
+		assertEquals(entity, actualEntity);
+	}
+
+	@Test
+	public void testPseudoBeanAccessor() {
+		PseudoBean entity = new PseudoBean();
+		entity.stringField = "stringField1";
+		entity.inheritedStringField = "inheritedStringField2";
+		entity.anEnum = AnEnum.ONE;
+		pseudoBeanAccessor.save(entity);
+
+		PseudoBean actualEntity = pseudoBeanAccessor.get(entity.getId());
+		assertEquals(entity, actualEntity);
+
+		actualEntity = pseudoBeanAccessor.get(entity.getId().toString());
+		assertEquals(entity, actualEntity);
+
+		actualEntity = pseudoBeanAccessor.findByCriteria(Map.of("stringField", "stringField1"));
+		assertEquals(entity, actualEntity);
+
+		actualEntity = pseudoBeanAccessor.findManyByCriteria(Map.of("stringField", "stringField1")).findFirst().get();
+		assertEquals(entity, actualEntity);
+
+		actualEntity = pseudoBeanAccessor.findByCriteria(Map.of("inheritedStringField", "inheritedStringField2"));
+		assertEquals(entity, actualEntity);
+
+		actualEntity = pseudoBeanAccessor.findManyByCriteria(Map.of("inheritedStringField", "inheritedStringField2")).findFirst().get();
+		assertEquals(entity, actualEntity);
+
+		actualEntity = pseudoBeanAccessor.findByCriteria(Map.of("anEnum", AnEnum.ONE.name()));
+		assertEquals(entity, actualEntity);
+
+		actualEntity = pseudoBeanAccessor.findManyByCriteria(Map.of("anEnum", AnEnum.ONE.name())).findFirst().get();
+		assertEquals(entity, actualEntity);
+
+		actualEntity = pseudoBeanAccessor.findByCriteria(new HashMap<> ());
 		assertEquals(entity, actualEntity);
 	}
 
@@ -203,5 +238,19 @@ public abstract class AbstractAccessorTest {
 			this.property1 = property1;
 		}
 	}
- 
+
+	public enum AnEnum {
+		ZERO,
+		ONE,
+		TWO
+	}
+	public static class PseudoBean extends PseudoBeanParentClass {
+		public String stringField;
+		public AnEnum anEnum;
+	}
+
+	public static class PseudoBeanParentClass extends AbstractIdentifiableObject {
+		public String inheritedStringField;
+	}
+
 }

--- a/step-framework-parent/step-framework-collections/src/test/java/step/core/accessors/CachedAccessorTest.java
+++ b/step-framework-parent/step-framework-collections/src/test/java/step/core/accessors/CachedAccessorTest.java
@@ -10,12 +10,14 @@ public class CachedAccessorTest extends AbstractAccessorTest {
 	private InMemoryAccessor<AbstractIdentifiableObject> underlyingAccessor = new InMemoryAccessor<>(false);
 	private InMemoryAccessor<AbstractOrganizableObject> underlyingOrganisableObjectAccessor = new InMemoryAccessor<>(false);
 	private InMemoryAccessor<Bean> underlyingBeanAccessor = new InMemoryAccessor<>(false);
-	
+	private InMemoryAccessor<PseudoBean> underlyingPseudoBeanAccessor = new InMemoryAccessor<>(false);
+
 	@Before
 	public void before() {
 		accessor = new CachedAccessor<AbstractIdentifiableObject>(underlyingAccessor);
 		organizableObjectAccessor = new CachedAccessor<AbstractOrganizableObject>(underlyingOrganisableObjectAccessor);
 		beanAccessor = new CachedAccessor<Bean>(underlyingBeanAccessor, false);
+		pseudoBeanAccessor = new CachedAccessor<>(underlyingPseudoBeanAccessor, false);
 	}
 	
 	@Test

--- a/step-framework-parent/step-framework-collections/src/test/java/step/core/accessors/CachedVersionedAccessorTest.java
+++ b/step-framework-parent/step-framework-collections/src/test/java/step/core/accessors/CachedVersionedAccessorTest.java
@@ -12,13 +12,16 @@ public class CachedVersionedAccessorTest extends AbstractVersionedAccessorTest {
 	private InMemoryAccessor<AbstractIdentifiableObject> underlyingAccessor = new InMemoryAccessor<>(false);
 	private InMemoryAccessor<AbstractOrganizableObject> underlyingOrganisableObjectAccessor = new InMemoryAccessor<>(false);
 	private InMemoryAccessor<Bean> underlyingBeanAccessor = new InMemoryAccessor<>(false);
-	
+	private InMemoryAccessor<PseudoBean> underlyingPseudoBeanAccessor = new InMemoryAccessor<>(false);
+
 	@Before
 	public void before() {
 		accessor = new CachedAccessor<AbstractIdentifiableObject>(underlyingAccessor);
 		organizableObjectAccessor = new CachedAccessor<AbstractOrganizableObject>(underlyingOrganisableObjectAccessor);
 		beanAccessor = new CachedAccessor<Bean>(underlyingBeanAccessor, false);
 		underlyingBeanAccessor.enableVersioning(new InMemoryCollection<>(false), 1l);
+		pseudoBeanAccessor = new CachedAccessor<>(underlyingPseudoBeanAccessor, false);
+		underlyingPseudoBeanAccessor.enableVersioning(new InMemoryCollection<>(false), 1l);
 	}
 	
 	@Test

--- a/step-framework-parent/step-framework-collections/src/test/java/step/core/accessors/FilesystemAccessorTest.java
+++ b/step-framework-parent/step-framework-collections/src/test/java/step/core/accessors/FilesystemAccessorTest.java
@@ -43,5 +43,7 @@ public class FilesystemAccessorTest extends AbstractAccessorTest {
 				new FilesystemCollection<>(repository, AbstractOrganizableObject.class));
 		beanAccessor = new AbstractAccessor<Bean>(
 				new FilesystemCollection<>(repository, Bean.class));
+		pseudoBeanAccessor = new AbstractAccessor<>(
+				new FilesystemCollection<>(repository, PseudoBean.class));
 	}
 }

--- a/step-framework-parent/step-framework-collections/src/test/java/step/core/accessors/FilesystemVersionedAccessorTest.java
+++ b/step-framework-parent/step-framework-collections/src/test/java/step/core/accessors/FilesystemVersionedAccessorTest.java
@@ -43,5 +43,8 @@ public class FilesystemVersionedAccessorTest extends AbstractVersionedAccessorTe
 		beanAccessor = new AbstractAccessor<Bean>(
 				new FilesystemCollection<>(repository, Bean.class));
 		beanAccessor.enableVersioning(new FilesystemCollection<>(repository, EntityVersion.class), 1l);
+		pseudoBeanAccessor = new AbstractAccessor<>(
+				new FilesystemCollection<>(repository, PseudoBean.class));
+		pseudoBeanAccessor.enableVersioning(new FilesystemCollection<>(repository, EntityVersion.class), 1l);
 	}
 }

--- a/step-framework-parent/step-framework-collections/src/test/java/step/core/accessors/InMemoryAccessorTest.java
+++ b/step-framework-parent/step-framework-collections/src/test/java/step/core/accessors/InMemoryAccessorTest.java
@@ -29,6 +29,7 @@ public class InMemoryAccessorTest extends AbstractAccessorTest {
 		accessor = new InMemoryAccessor<>(false);
 		organizableObjectAccessor = new InMemoryAccessor<>(false);
 		beanAccessor = new InMemoryAccessor<>(false);
+		pseudoBeanAccessor = new InMemoryAccessor<>(false);
 	}
 
 }

--- a/step-framework-parent/step-framework-collections/src/test/java/step/core/accessors/InMemoryVersionedAccessorTest.java
+++ b/step-framework-parent/step-framework-collections/src/test/java/step/core/accessors/InMemoryVersionedAccessorTest.java
@@ -31,6 +31,8 @@ public class InMemoryVersionedAccessorTest extends AbstractVersionedAccessorTest
 		beanAccessor = new InMemoryAccessor<>(false);
 		//enable versioning
 		beanAccessor.enableVersioning(new InMemoryCollection<>(false), 1l);
+		pseudoBeanAccessor = new InMemoryAccessor<>(false);
+		pseudoBeanAccessor.enableVersioning(new InMemoryCollection<>(false), 1l);
 	}
 
 }


### PR DESCRIPTION
Currently, POJOs are explicitly required to be Beans (i.e., have getters for their properties) when accessed via reflection. This results in lots of overhead for simple struct classes; instead of simply having one public field, the field is hidden, but public getters and setters exist which effectively turn the field public anyway - but require 7 lines instead of 1.

This allows property lookup by checking fields in addition to getter methods (at the core, it’s just 5 lines of additional code).