### PR TITLE
SED-3164-switch percentile to double

### DIFF
--- a/step-framework-parent/step-framework-timeseries/src/main/java/step/core/timeseries/bucket/Bucket.java
+++ b/step-framework-parent/step-framework-timeseries/src/main/java/step/core/timeseries/bucket/Bucket.java
@@ -95,8 +95,11 @@ public class Bucket extends AbstractIdentifiableObject {
         this.distribution = distribution;
     }
 
-    public long getPercentile(int percentile) {
-        long numberOfPointsAtPercentile = (long) (1.0 * percentile / 100 * count);
+    public long getPercentile(double percentile) {
+        if (percentile < 0.0 || percentile > 100.0) {
+            throw new IllegalArgumentException("Percentile must be between 0.0 and 100.0");
+        }
+        long numberOfPointsAtPercentile = (long) Math.ceil(percentile / 100 * count);
         LongAdder count = new LongAdder();
         long percentileValue = 0;
 

--- a/step-framework-parent/step-framework-timeseries/src/main/java/step/core/timeseries/metric/MetricAggregation.java
+++ b/step-framework-parent/step-framework-timeseries/src/main/java/step/core/timeseries/metric/MetricAggregation.java
@@ -1,10 +1,13 @@
 package step.core.timeseries.metric;
 
+import jakarta.validation.constraints.NotNull;
+
 import java.util.Map;
 
 
 
 public class MetricAggregation {
+    @NotNull
     private MetricAggregationType type;
     private Map<String, Object> params;
 

--- a/step-framework-parent/step-framework-timeseries/src/main/java/step/core/timeseries/metric/MetricAggregation.java
+++ b/step-framework-parent/step-framework-timeseries/src/main/java/step/core/timeseries/metric/MetricAggregation.java
@@ -1,12 +1,40 @@
 package step.core.timeseries.metric;
 
-public enum MetricAggregation {
-    SUM,
-    AVG,
-    MAX,
-    MIN,
-    COUNT,
-    RATE,
-    MEDIAN,
-    PERCENTILE
+import java.util.Map;
+
+
+
+public class MetricAggregation {
+    private MetricAggregationType type;
+    private Map<String, Object> params;
+
+    public MetricAggregation() {
+    }
+    
+    public MetricAggregation(MetricAggregationType type) {
+        this.type = type;
+    }
+
+    public MetricAggregation(MetricAggregationType type, Map<String, Object> params) {
+        this.type = type;
+        this.params = params;
+    }
+
+    public MetricAggregationType getType() {
+        return type;
+    }
+
+    public MetricAggregation setType(MetricAggregationType type) {
+        this.type = type;
+        return this;
+    }
+
+    public Map<String, Object> getParams() {
+        return params;
+    }
+
+    public MetricAggregation setParams(Map<String, Object> params) {
+        this.params = params;
+        return this;
+    }
 }

--- a/step-framework-parent/step-framework-timeseries/src/main/java/step/core/timeseries/metric/MetricAggregationType.java
+++ b/step-framework-parent/step-framework-timeseries/src/main/java/step/core/timeseries/metric/MetricAggregationType.java
@@ -1,0 +1,12 @@
+package step.core.timeseries.metric;
+
+public enum MetricAggregationType {
+    SUM,
+    AVG,
+    MAX,
+    MIN,
+    COUNT,
+    RATE,
+    MEDIAN,
+    PERCENTILE
+}

--- a/step-framework-parent/step-framework-timeseries/src/test/java/step/core/timeseries/BucketTest.java
+++ b/step-framework-parent/step-framework-timeseries/src/test/java/step/core/timeseries/BucketTest.java
@@ -3,6 +3,7 @@ package step.core.timeseries;
 import org.junit.Test;
 import step.core.timeseries.bucket.Bucket;
 
+import java.util.TreeMap;
 import java.util.concurrent.ConcurrentHashMap;
 
 import static org.junit.Assert.assertEquals;
@@ -29,5 +30,23 @@ public class BucketTest {
         assertEquals(1L, bucket.getPercentile(1));
         assertEquals(20L, bucket.getPercentile(50));
         assertEquals(25L, bucket.getPercentile(100));
+    }
+    
+    @Test
+    public void getDistributionWithDecimals() {
+        Bucket bucket = new Bucket();
+        TreeMap<Long, Long> distribution = new TreeMap<>();
+        int count = 100;
+        bucket.setCount(count);
+        bucket.setDistribution(distribution);
+        
+        for (int i = 0; i < count; i+=2) {
+            distribution.put(i * 10L, 2L); // all will be above 100
+        }
+
+        assertEquals(80, bucket.getPercentile(9.5));
+        assertEquals(80, bucket.getPercentile(10));
+        assertEquals(100, bucket.getPercentile(10.5));
+        assertEquals(480L, bucket.getPercentile(50));
     }
 }

--- a/step-framework-parent/step-framework-timeseries/src/test/java/step/core/timeseries/MetricTypeTest.java
+++ b/step-framework-parent/step-framework-timeseries/src/test/java/step/core/timeseries/MetricTypeTest.java
@@ -4,18 +4,31 @@ import org.junit.Assert;
 import org.junit.Test;
 import step.core.timeseries.metric.*;
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 public class MetricTypeTest {
 
+    @Test
+    public void testMetricAggregationParams() {
+         MetricAggregation aggregation = new MetricAggregation(MetricAggregationType.PERCENTILE, Map.of("pclValue", 80));
+         MetricType metric = new MetricType()
+                .setName("newMetric")
+                .setDisplayName("label")
+                .setDescription("Custom description")
+                .setAttributes(Collections.emptyList())
+                .setDefaultAggregation(aggregation)
+                .setDefaultGroupingAttributes(Arrays.asList("name"))
+                .setUnit("unit");
+         Assert.assertEquals(80, metric.getDefaultAggregation().getParams().get("pclValue"));
+         
+    }
+    
     @Test
     public void testBaseModel() {
         String name = "metricName";
         String label = "metricLabel";
         String unit = "ms";
-        MetricAggregation aggregation = MetricAggregation.COUNT;
+        MetricAggregation aggregation = new MetricAggregation(MetricAggregationType.COUNT);
         Map<String, String> seriesColors = Map.of();
         List<MetricAttribute> attributes = Arrays.asList(new MetricAttribute().setDisplayName("displayName").setName("name"));
 


### PR DESCRIPTION
@david-stephan if you think we can have backwards compatible issues, I could overload the method with a long parameter also, which would just call the double one inside