### PR TITLE
SED-3439 prepare for Step 26

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,3 @@
-# exense-commons
+# step-framework
 
 This repository hosts components reused across a variety of applications built internally at exense and is open for external collaboration purposes. Over time, this project aims to support (in a simple and convenient way) a majority of the features normally supported by complex application servers.
-
-Current stack:
-- Jetty 9.4
-- Jersey 2.29
-- Mongo 3.12
-- Jackson 2.10
-- Pac4J 4.0.0 (WIP - experimental)
-
-Public developper documentation is currently being build in this repo's [wiki](https://github.com/exense/exense-commons/wiki/Developer-Docs).

--- a/pom.xml
+++ b/pom.xml
@@ -43,14 +43,13 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <!-- internal dependencies -->
-        <exense-commons.version>2024.8.29-66d0408ee9f5583e61b7fb52</exense-commons.version>
-        <dependencies.version>2024.8.27</dependencies.version>
+        <exense-commons.version>2.0.9</exense-commons.version>
+        <dependencies.version>2024.9.26</dependencies.version>
 
-        <!-- external dependencies, to be re-checked for candidates for upstreaming into exense-dependencies -->
+        <!-- external dependencies -->
         <dep.jaxb.version>2.3.1</dep.jaxb.version>
         <dep.antlr.version>4.5.3</dep.antlr.version>
         <dep.classgraph.version>4.8.147</dep.classgraph.version>
-
         <dep.swagger-ui.version>5.17.14</dep.swagger-ui.version>
 
         <!-- maven build dependencies -->


### PR DESCRIPTION
Suggest to also bump this to 2.1.0 as there seem to be quite a few changes, otherwise the next version would be 2.0.17.