### PR TITLE
SED-4114 PostgreSQL collection queries load all results into memory

### DIFF
--- a/build_parameters.json
+++ b/build_parameters.json
@@ -16,7 +16,7 @@
 		},
 		{
 			"NAME": "PRODUCTION",
-			"URL": "sonatype::https://oss.sonatype.org/service/local/staging/deploy/maven2",
+			"URL": "sonatype::https://obsolete",
 			"CONFIG": "SignedBuild"
 		}
 	]

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,6 @@
         <maven.compiler.release>11</maven.compiler.release>
         <!-- internal dependencies -->
         <exense-commons.version>2.0.11</exense-commons.version>
-
         <dependencies.version>2025.3.14</dependencies.version>
 
         <!-- external dependencies -->
@@ -470,6 +469,26 @@
                                 </configuration>
                             </execution>
                         </executions>
+                    </plugin>
+
+                    <!-- Disable old maven-deploy plugin -->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-deploy-plugin</artifactId>
+                        <configuration>
+                            <skip>true</skip>
+                        </configuration>
+                    </plugin>
+
+                    <!-- Publish directly to central instead -->
+                    <plugin>
+                        <groupId>org.sonatype.central</groupId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
+                        <version>0.8.0</version>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <publishingServerId>sonatype</publishingServerId>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/step-framework-collections-mongodb/pom.xml
+++ b/step-framework-collections-mongodb/pom.xml
@@ -4,6 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	
 	<artifactId>step-framework-collections-mongodb</artifactId>
+	<name>${project.groupId}:${project.artifactId}</name>
 	<packaging>jar</packaging>
 	
 	<parent>

--- a/step-framework-collections-postgresql/pom.xml
+++ b/step-framework-collections-postgresql/pom.xml
@@ -5,6 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>step-framework-collections-postgresql</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
     <packaging>jar</packaging>
 
     <parent>

--- a/step-framework-collections-postgresql/src/main/java/step/core/collections/postgresql/PostgreSQLCollection.java
+++ b/step-framework-collections-postgresql/src/main/java/step/core/collections/postgresql/PostgreSQLCollection.java
@@ -21,6 +21,7 @@ package step.core.collections.postgresql;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.zaxxer.hikari.HikariDataSource;
+import com.zaxxer.hikari.pool.HikariProxyStatement;
 import org.apache.commons.beanutils.PropertyUtils;
 import org.bson.types.ObjectId;
 import org.slf4j.Logger;
@@ -40,6 +41,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
+@SuppressWarnings({"SqlSourceToSinkFlow", "SqlNoDataSourceInspection"})
 public class PostgreSQLCollection<T> extends AbstractCollection<T> implements Collection<T> {
 
 	private static Pattern p = Pattern.compile("([^.]+)");
@@ -79,7 +81,7 @@ public class PostgreSQLCollection<T> extends AbstractCollection<T> implements Co
 	private synchronized void createTableIfRequired() throws SQLException {
 		try (Connection connection = ds.getConnection()) {
 			if (!tableExists(connection)) {
-				try (Statement statement = connection.createStatement();) {
+				try (Statement statement = connection.createStatement()) {
 					statement.executeUpdate("CREATE TABLE " + collectionNameStr + " (" +
 							"id text GENERATED ALWAYS AS  (object ->> 'id') STORED, " +
 							"object jsonb NOT NULL,"+
@@ -119,47 +121,42 @@ public class PostgreSQLCollection<T> extends AbstractCollection<T> implements Co
 
 	@Override
 	public long estimatedCount() {
-		String query = "SELECT reltuples AS estimate FROM pg_class WHERE relname = '" + collectionName + "'" ;
+		String query = "SELECT reltuples AS estimate FROM pg_class WHERE relname = ?";
 		try {
 			try (Connection connection = ds.getConnection();
-				 PreparedStatement preparedStatement = connection.prepareStatement(query);
-				 ResultSet resultSet = preparedStatement.executeQuery()) {
-				if (resultSet.next()) {
-					return resultSet.getInt(1);
-				} else {
-					throw new RuntimeException("Unable to estimate the count for collection: " + collectionName + " , query: " + query);
+				 PreparedStatement preparedStatement = connection.prepareStatement(query)) {
+				preparedStatement.setString(1, collectionName);
+				try (ResultSet resultSet = preparedStatement.executeQuery()) {
+					if (resultSet.next()) {
+						return resultSet.getInt(1);
+					} else {
+						throw new RuntimeException("Unable to estimate the count for collection: " + collectionName + " , query: " + query);
+					}
 				}
 			}
 		} catch (SQLException e) {
-			throw new RuntimeException("Query execution failed: " + query,e);
+			throw new RuntimeException("Query execution failed: " + query, e);
 		}
 	}
 
 	@Override
 	public Stream<T> find(Filter filter, SearchOrder order, Integer skip, Integer limit, int maxTime) {
 		String query = buildQuery(filter, order, skip, limit);
-		try (Connection connection = ds.getConnection();
-			 Statement statement = connection.createStatement()){
-			if (maxTime > 0) {
-				statement.setQueryTimeout(maxTime);
+		List<String> resultList = new ArrayList<>();
+		try (StreamingQuery sq = new StreamingQuery(ds, query, maxTime)) {
+			while (sq.resultSet.next()) {
+				resultList.add(sq.resultSet.getString(2));
 			}
-			 try (ResultSet resultSet = statement.executeQuery(query)) {
-				 List<String> resultList = new ArrayList<>();
-				 while (resultSet.next()) {
-					 resultList.add(resultSet.getString(2));
-				 }
-
-				 return resultList.stream().map(s-> {
-					 try {
-						 return objectMapper.readValue(s, entityClass);
-					 } catch (JsonProcessingException e) {
-						 throw new RuntimeException(e);
-					 }
-				 });
-			 }
 		} catch (SQLException e) {
-			throw new RuntimeException("Query execution failed: " + query,e);
+			throw new RuntimeException("Query execution failed: " + query, e);
 		}
+		return resultList.stream().map(s -> {
+			try {
+				return objectMapper.readValue(s, entityClass);
+			} catch (JsonProcessingException e) {
+				throw new RuntimeException(e);
+			}
+		});
 	}
 
 	private String buildQuery(Filter filter, SearchOrder order, Integer skip, Integer limit) {
@@ -184,58 +181,33 @@ public class PostgreSQLCollection<T> extends AbstractCollection<T> implements Co
 	@Override
 	public Stream<T> findLazy(Filter filter, SearchOrder order, Integer skip, Integer limit, int maxTime) {
 		String query = buildQuery(filter, order, skip, limit);
-		AtomicReference<Connection> connection = new AtomicReference<>();
-		AtomicReference<Statement> statement = new AtomicReference<>();
-		AtomicReference<ResultSet> resultSet = new AtomicReference<>();
+		AtomicReference<StreamingQuery> queryRef = new AtomicReference<>();
 		try {
-			connection.set(ds.getConnection());
-			statement.set(connection.get().createStatement());
-			if (maxTime > 0) {
-				statement.get().setQueryTimeout(maxTime);
-			}
-			resultSet.set(statement.get().executeQuery(query));
-
-			Stream<T> stream = StreamSupport.stream(Spliterators.spliteratorUnknownSize(new ResultSetIterator(resultSet.get()),
+			queryRef.set(new StreamingQuery(ds, query));
+			return StreamSupport.stream(Spliterators.spliteratorUnknownSize(new ResultSetIterator(queryRef.get().resultSet),
 							Spliterator.IMMUTABLE | Spliterator.NONNULL | Spliterator.ORDERED), false)
-					.map(s-> {
+					.map(s -> {
 						try {
 							return objectMapper.readValue(s, entityClass);
 						} catch (JsonProcessingException e) {
 							throw new RuntimeException(e);
 						}
-					});
-			stream.onClose(() -> safeClose(connection.get(), statement.get(), resultSet.get()));
-			return stream;
+					}).onClose(() -> safeClose(queryRef.get()));
 		} catch (SQLException e) {
-			safeClose(connection.get(), statement.get(), resultSet.get());
-			throw new RuntimeException("Query execution failed: " + query,e);
+			safeClose(queryRef.get());
+			throw new RuntimeException("Query execution failed: " + query, e);
 		}
 	}
 
-	private void safeClose(Connection connection, Statement statement, ResultSet resultSet) {
-		if (resultSet != null) {
-			try {
-				resultSet.close();
-			} catch (SQLException e) {
-				logger.error("Unable to close resultSet" ,e);
+	private void safeClose(StreamingQuery streamingQuery) {
+		try {
+			if (streamingQuery != null) {
+				streamingQuery.close();
 			}
-		}
-		if (statement!= null) {
-			try {
-				statement.close();
-			} catch (SQLException e) {
-				logger.error("Unable to close statement" ,e);
-			}
-		}
-		if (connection != null) {
-			try {
-				connection.close();
-			} catch (SQLException e) {
-				logger.error("Unable to close connection" ,e);
-			}
+		} catch (Exception e) {
+			logger.error("Exception while closing {}", streamingQuery.getClass().getSimpleName(), e);
 		}
 	}
-
 
 	@Override
 	public Stream<T> findReduced(Filter filter, SearchOrder order, Integer skip, Integer limit, int maxTime, List<String> reduceFields) {
@@ -248,12 +220,10 @@ public class PostgreSQLCollection<T> extends AbstractCollection<T> implements Co
 		Class fieldClass = getFieldClass(columnName);
 		StringBuffer query = new StringBuffer();
 		query.append("SELECT DISTINCT(").append(PostgreSQLFilterFactory.formatField(columnName,fieldClass)).append(") FROM ").append(collectionNameStr).append(" WHERE ").append(filterToWhereClause(filter));
-		try (Connection connection = ds.getConnection();
-			 Statement statement = connection.createStatement();
-			 ResultSet resultSet = statement.executeQuery(query.toString())){
+		try (StreamingQuery sq = new StreamingQuery(ds, query.toString())){
 			List<String> resultList = new ArrayList<>();
-			while (resultSet.next()) {
-				resultList.add(resultSet.getString(1));
+			while (sq.resultSet.next()) {
+				resultList.add(sq.resultSet.getString(1));
 			}
 			return resultList;
 		} catch (SQLException e) {

--- a/step-framework-collections-postgresql/src/main/java/step/core/collections/postgresql/PostgreSQLCollectionFactory.java
+++ b/step-framework-collections-postgresql/src/main/java/step/core/collections/postgresql/PostgreSQLCollectionFactory.java
@@ -28,10 +28,7 @@ import step.core.collections.CollectionFactory;
 import step.core.collections.EntityVersion;
 
 import java.io.IOException;
-import java.sql.Connection;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.sql.Statement;
+import java.sql.*;
 import java.util.Properties;
 
 public class PostgreSQLCollectionFactory implements CollectionFactory {
@@ -70,7 +67,7 @@ public class PostgreSQLCollectionFactory implements CollectionFactory {
 		ds.close();
 	}
 
-	private HikariDataSource createConnectionPool(Properties properties) {
+	static HikariDataSource createConnectionPool(Properties properties) {
 		HikariConfig config = new HikariConfig();
 		String jdbcUrl = properties.getProperty("jdbcUrl");
 		config.setJdbcUrl(jdbcUrl);
@@ -83,6 +80,9 @@ public class PostgreSQLCollectionFactory implements CollectionFactory {
 		config.addDataSourceProperty( "cachePrepStmts" , "true" );
 		config.addDataSourceProperty( "prepStmtCacheSize" , "250" );
 		config.addDataSourceProperty( "prepStmtCacheSqlLimit" , "2048" );
+		// Just to make the default explicit: every connection acquired from the data source will initially have auto-commit on.
+		// (this is also the case if the connection is re-used: it will be reset with auto-commit on before being returned)
+		config.setAutoCommit( true );
 		HikariDataSource hikariDataSource = null;
 		try {
 			hikariDataSource = new HikariDataSource(config);
@@ -101,7 +101,7 @@ public class PostgreSQLCollectionFactory implements CollectionFactory {
 		return hikariDataSource;
 	}
 
-	private void createDatabase(Properties properties, String jdbcUrl) throws SQLException {
+	private static void createDatabase(Properties properties, String jdbcUrl) throws SQLException {
 		int lastSlash = jdbcUrl.lastIndexOf("/");
 		String serverUrl = jdbcUrl.substring(0,lastSlash+1);
 		String dbName = jdbcUrl.replace(serverUrl,"").replaceFirst("\\?.*","");

--- a/step-framework-collections-postgresql/src/main/java/step/core/collections/postgresql/StreamingQuery.java
+++ b/step-framework-collections-postgresql/src/main/java/step/core/collections/postgresql/StreamingQuery.java
@@ -1,0 +1,69 @@
+package step.core.collections.postgresql;
+
+import javax.sql.DataSource;
+import java.sql.*;
+
+public class StreamingQuery implements AutoCloseable {
+    private static final int FETCH_SIZE = 1000;
+    private final Connection connection;
+    private final PreparedStatement statement;
+    public final ResultSet resultSet;
+
+    public StreamingQuery(DataSource ds, String sql) throws SQLException {
+        this(ds, sql, 0);
+    }
+
+    public StreamingQuery(DataSource ds, String sql, int timeoutSeconds) throws SQLException {
+        Connection conn = null;
+        PreparedStatement stmt = null;
+        try {
+            conn = ds.getConnection();
+            conn.setAutoCommit(false);
+            stmt = conn.prepareStatement(sql, ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY);
+            stmt.setFetchSize(FETCH_SIZE);
+            if (timeoutSeconds > 0) {
+                stmt.setQueryTimeout(timeoutSeconds);
+            }
+            resultSet = stmt.executeQuery();
+            statement = stmt;
+            connection = conn;
+        } catch (SQLException sqlEx) {
+            try {
+                close(stmt, conn);
+            } catch (Exception ex) {
+                sqlEx.addSuppressed(ex);
+            }
+            throw sqlEx;
+        }
+    }
+
+    private void close(AutoCloseable... closeables) throws SQLException {
+        SQLException exception = null;
+
+        for (AutoCloseable closeable : closeables) {
+            if (closeable != null) {
+                try {
+                    closeable.close();
+                } catch (Exception e) {
+                    if (exception == null) {
+                        if (e instanceof SQLException) {
+                            exception = (SQLException) e;
+                        } else {
+                            exception = new SQLException(e.getMessage(), e);
+                        }
+                    } else {
+                        exception.addSuppressed(e);
+                    }
+                }
+            }
+        }
+        if (exception != null) {
+            throw exception;
+        }
+    }
+
+    @Override
+    public void close() throws SQLException {
+        close(resultSet, statement, connection);
+    }
+}

--- a/step-framework-collections/pom.xml
+++ b/step-framework-collections/pom.xml
@@ -4,6 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	
 	<artifactId>step-framework-collections</artifactId>
+	<name>${project.groupId}:${project.artifactId}</name>
 	<packaging>jar</packaging>
 	
 	<parent>

--- a/step-framework-core/pom.xml
+++ b/step-framework-core/pom.xml
@@ -4,6 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	
 	<artifactId>step-framework-core</artifactId>
+	<name>${project.groupId}:${project.artifactId}</name>
 	<packaging>jar</packaging>
 	
 	<parent>

--- a/step-framework-model/pom.xml
+++ b/step-framework-model/pom.xml
@@ -4,6 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	
 	<artifactId>step-framework-model</artifactId>
+	<name>${project.groupId}:${project.artifactId}</name>
 	<packaging>jar</packaging>
 	
 	<parent>

--- a/step-framework-server-plugins/pom.xml
+++ b/step-framework-server-plugins/pom.xml
@@ -4,6 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	
 	<artifactId>step-framework-server-plugins</artifactId>
+	<name>${project.groupId}:${project.artifactId}</name>
 	<packaging>jar</packaging>
 	
 	<parent>

--- a/step-framework-server/pom.xml
+++ b/step-framework-server/pom.xml
@@ -4,6 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	
 	<artifactId>step-framework-server</artifactId>
+	<name>${project.groupId}:${project.artifactId}</name>
 	<packaging>jar</packaging>
 	
 	<parent>

--- a/step-framework-timeseries/pom.xml
+++ b/step-framework-timeseries/pom.xml
@@ -4,6 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	
 	<artifactId>step-framework-timeseries</artifactId>
+	<name>${project.groupId}:${project.artifactId}</name>
 	<packaging>jar</packaging>
 	
 	<parent>


### PR DESCRIPTION
Note: only the first commit has relevant functional changes (and will be cherry-picked to master). The second one is a backport of the changes required to be able to publish.